### PR TITLE
feat: Add Docker deployment with bundled SentenceTransformer model

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,3 +49,6 @@ service.yaml
 qbgen-landing/node_modules/
 qbgen-landing/.next/
 qbgen-landing/.pnpm/
+
+# Model files (will be downloaded during build)
+backend/models/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,17 @@ RUN npm install -g pnpm
 # Install dependencies
 RUN pnpm install --frozen-lockfile
 
-# Copy frontend source code
-COPY qbgen-landing/ ./
+# Copy frontend source code (excluding node_modules to avoid conflicts)
+COPY qbgen-landing/app ./app
+COPY qbgen-landing/components ./components
+COPY qbgen-landing/lib ./lib
+COPY qbgen-landing/hooks ./hooks
+COPY qbgen-landing/public ./public
+COPY qbgen-landing/styles ./styles
+COPY qbgen-landing/*.js ./
+COPY qbgen-landing/*.json ./
+COPY qbgen-landing/*.mjs ./
+COPY qbgen-landing/*.ts ./
 
 # Build the Next.js application
 RUN pnpm build
@@ -40,6 +49,10 @@ WORKDIR /app
 COPY backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt && \
     python -m spacy download en_core_web_sm
+
+# Copy model download script and download the model
+COPY download_model.py .
+RUN python download_model.py
 
 # Copy backend source code
 COPY backend/ ./backend/

--- a/backend/app.py
+++ b/backend/app.py
@@ -15,7 +15,14 @@ app = Flask(__name__)
 CORS(app)
 
 # Use sentence-transformers to get the same Universal Sentence Encoder model
-embed = SentenceTransformer('all-MiniLM-L6-v2')  # This is equivalent to Universal Sentence Encoder
+# Load from local model to avoid Hugging Face rate limits
+model_path = os.path.join(os.path.dirname(__file__), 'models', 'all-MiniLM-L6-v2')
+if os.path.exists(model_path):
+    print("Loading model from local path:", model_path)
+    embed = SentenceTransformer(model_path)
+else:
+    print("Local model not found, downloading from Hugging Face...")
+    embed = SentenceTransformer('all-MiniLM-L6-v2')
 nlp = spacy.load('en_core_web_sm')
 
 def get_frequency_list(subcategory, level="high-school", limit=5):
@@ -250,6 +257,10 @@ def serve_frontend():
 
 @app.route('/<path:path>')
 def serve_static(path):
+    # Skip API routes - let them be handled by their specific routes
+    if path.startswith('api/') or path.startswith('process_') or path.startswith('get_') or path.startswith('generate_'):
+        return jsonify({'error': 'API endpoint not found'}), 404
+    
     # Handle Next.js static export routing
     # First check if the path is a directory (ends with /)
     if path.endswith('/'):

--- a/download_model.py
+++ b/download_model.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+Script to download the SentenceTransformer model locally
+This avoids Hugging Face rate limits during deployment
+"""
+
+import os
+from sentence_transformers import SentenceTransformer
+
+def download_model():
+    """Download the all-MiniLM-L6-v2 model locally"""
+    print("Downloading SentenceTransformer model: all-MiniLM-L6-v2")
+    
+    # Create models directory
+    models_dir = "backend/models"
+    os.makedirs(models_dir, exist_ok=True)
+    
+    # Download the model
+    model = SentenceTransformer('all-MiniLM-L6-v2')
+    
+    # Save the model locally
+    model_path = os.path.join(models_dir, "all-MiniLM-L6-v2")
+    model.save(model_path)
+    
+    print(f"Model saved to: {model_path}")
+    print("Model download complete!")
+
+if __name__ == "__main__":
+    download_model()


### PR DESCRIPTION
- Bundle all-MiniLM-L6-v2 model locally to avoid Hugging Face rate limits
- Fix Flask API routes being caught by catch-all static route
- Update Dockerfile for multi-stage build with Next.js frontend and Python backend
- Add model download script for containerized deployment
- Update .dockerignore to exclude model files from build context
- Tested locally: API endpoints and frontend working correctly