### PR TITLE
fix: Resolve Next.js build and Docker integration issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,7 +13,6 @@ venv/
 **/.next/
 **/dist/
 **/build/
-**/out/
 
 # Development files
 .git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,8 @@ RUN python download_model.py
 # Copy backend source code
 COPY backend/ ./backend/
 
-# Copy the built Next.js frontend static files
-COPY --from=frontend-builder /app/frontend/out/ ./static/
+# Copy the built Next.js static export from host (pre-built)
+COPY qbgen-landing/out/ ./static/
 
 # Create a simple startup script
 RUN echo '#!/bin/bash\n\

--- a/qbgen-landing/next.config.mjs
+++ b/qbgen-landing/next.config.mjs
@@ -14,6 +14,18 @@ const nextConfig = {
   assetPrefix: '',
   basePath: '',
   distDir: 'out',
+  experimental: {
+    outputFileTracingRoot: undefined,
+  },
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        fs: false,
+      };
+    }
+    return config;
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
- Fix Next.js static export build by adding webpack fallback configuration
- Remove **/out/ from .dockerignore to allow copying static files
- Update Dockerfile to copy pre-built static files from host
- Verify both frontend and backend are working correctly in Docker container
- Test API endpoints (health, get_sets) and frontend serving
- Bundle SentenceTransformer model locally to avoid Hugging Face rate limits