### PR TITLE
fix: Resolve Docker build failure with wildcard COPY commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,17 @@ COPY qbgen-landing/lib ./lib
 COPY qbgen-landing/hooks ./hooks
 COPY qbgen-landing/public ./public
 COPY qbgen-landing/styles ./styles
-COPY qbgen-landing/*.js ./
-COPY qbgen-landing/*.json ./
-COPY qbgen-landing/*.mjs ./
-COPY qbgen-landing/*.ts ./
+
+# Copy configuration files (use individual files to avoid wildcard issues)
+COPY qbgen-landing/next.config.mjs ./
+COPY qbgen-landing/tsconfig.json ./
+COPY qbgen-landing/tailwind.config.js ./
+COPY qbgen-landing/postcss.config.mjs ./
+COPY qbgen-landing/components.json ./
+COPY qbgen-landing/next-env.d.ts ./
 
 # Build the Next.js application
+    
 RUN pnpm build
 
 # Production stage with Python backend


### PR DESCRIPTION
- Replace wildcard COPY commands (*.js, *.json, *.mjs, *.ts) with explicit file copies
- This prevents build failures when no files match the wildcard patterns
- Fixes Google Cloud Build error: 'no source files were specified'
- Tested locally: Docker build now completes successfully