### PR TITLE
fix: Remove non-existent next-env.d.ts from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ COPY qbgen-landing/tsconfig.json ./
 COPY qbgen-landing/tailwind.config.js ./
 COPY qbgen-landing/postcss.config.mjs ./
 COPY qbgen-landing/components.json ./
-COPY qbgen-landing/next-env.d.ts ./
 
 # Build the Next.js application
     


### PR DESCRIPTION
- Remove COPY qbgen-landing/next-env.d.ts ./ as file doesn't exist in source
- This was causing Google Cloud Build to fail with 'file not found'
- Docker build now completes successfully and includes both frontend and backend
- Tested locally: build works correctly