### PR TITLE
fix: Use multi-stage build to copy Next.js output from frontend-build…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,8 @@ RUN python download_model.py
 # Copy backend source code
 COPY backend/ ./backend/
 
-# Copy the built Next.js static export from host (pre-built)
-COPY qbgen-landing/out/ ./static/
+# Copy the built Next.js static export from the frontend-builder stage
+COPY --from=frontend-builder /app/frontend/out/ ./static/
 
 # Create a simple startup script
 RUN echo '#!/bin/bash\n\


### PR DESCRIPTION
…er stage

- Change from copying pre-built out/ directory from host to copying from frontend-builder stage
- This fixes Google Cloud Build error: 'qbgen-landing/out/: file does not exist'
- The out/ directory is built inside the Docker container, not on the host
- Both frontend and backend now work correctly in the container
- Tested locally: full application working with API and frontend integration